### PR TITLE
Remove unnesserary macOS debug log

### DIFF
--- a/simpleble/src/backends/macos/PeripheralBaseMacOS.mm
+++ b/simpleble/src/backends/macos/PeripheralBaseMacOS.mm
@@ -673,7 +673,6 @@
 }
 
 - (void)peripheralIsReadyToSendWriteWithoutResponse:(CBPeripheral*)peripheral {
-    NSLog(@"Peripheral ready to send: %@", peripheral);
 }
 
 - (void)peripheral:(CBPeripheral*)peripheral didUpdateValueForDescriptor:(CBDescriptor*)descriptor error:(NSError*)error {


### PR DESCRIPTION
This pull request removes what appears to be an unnecessary debug log that floods the console when _Write Without Response_ is used.